### PR TITLE
Updates FluxHelmRelease API to v1alpha2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To record that you want a chart release, you create a resource of the kind `Flux
 ### Example
 ```
 ---
-apiVersion: helm.integrations.flux.weave.works/v1alpha
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
 kind: FluxHelmRelease
 metadata:
   name: mongodb

--- a/artifacts/fluxhelmreleases-crd.yaml
+++ b/artifacts/fluxhelmreleases-crd.yaml
@@ -10,4 +10,4 @@ spec:
     listKind: FluxHelmReleaseList
     plural: fluxhelmreleases
   scope: Namespaced
-  version: v1alpha               
+  version: v1alpha2

--- a/artifacts/weave-helm-operator.yaml
+++ b/artifacts/weave-helm-operator.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: weave-flux
       containers:
       - name: weave-flux-helm-operator
-        image: 'quay.io/weaveworks/helm-operator:alpha'
+        image: 'quay.io/weaveworks/helm-operator:0.1.0-alpha'
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: git-key

--- a/config/mariadb_release.yaml
+++ b/config/mariadb_release.yaml
@@ -1,5 +1,5 @@
 ---
-  apiVersion: helm.integrations.flux.weave.works/v1alpha
+  apiVersion: helm.integrations.flux.weave.works/v1alpha2
   kind: FluxHelmRelease
   metadata:
     name: mariadb

--- a/config/mongodb_release.yaml
+++ b/config/mongodb_release.yaml
@@ -1,5 +1,5 @@
 ---
-  apiVersion: helm.integrations.flux.weave.works/v1alpha
+  apiVersion: helm.integrations.flux.weave.works/v1alpha2
   kind: FluxHelmRelease
   metadata:
     name: mongodb


### PR DESCRIPTION
Reasons:

- Incorrect initial API version, inconsistent with the Kubernetes one
- Breaking change in the FluxHelmRelease schema
(#1035)

Note:
Main changes made in the flux codebase (https://github.com/weaveworks/flux/pull/1061)