### PR TITLE
Update ssh form instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ operator alpha. It is best to use a fresh Kubernetes cluster.
 
  1. Set up helm by running `helm init`, as in [Helm's installation instructions](https://docs.helm.sh/using_helm/#quickstart).
  2. Make a fork of this repository to your own account, and clone it to your computer
- 3. In your cloned repo, change the git URL in `artifacts/weave-helm-operator.yaml` to refer to your fork on github
+ 3. In your cloned repo, change the git URL in
+    `artifacts/weave-helm-operator.yaml` to refer to your fork on github. Make
+    sure to use the full ssh form of the url.
+    - Good: `ssh://git@github.com/weaveworks/flux-helm-test`
+    - Bad: `git@github.com:weaveworks/flux-helm-test.git`
  4. Go to [Weave Cloud](https://cloud.weave.works/) and create an instance
  5. Set up the Weave agents by running the provided curl command
 

--- a/artifacts/weave-helm-operator.yaml
+++ b/artifacts/weave-helm-operator.yaml
@@ -39,6 +39,6 @@ spec:
           readOnly: true # this will be the case perforce in K8s >=1.10
         args:
         # replace (at least) the following URL
-        - '--git-url=git@github.com:weaveworks/flux-helm-test.git'
+        - '--git-url=ssh://git@github.com/weaveworks/flux-helm-test'
         - '--git-branch=master'
         - '--git-charts-path=charts'


### PR DESCRIPTION
You get a confusing error message if you use the wrong form. "Cannot parse git url", when it looks like quite a nice git url.

Fixes #9 