### PR TITLE
Remove FluxHelmRelease label sections

### DIFF
--- a/releases/mariadb_release.yaml
+++ b/releases/mariadb_release.yaml
@@ -4,8 +4,6 @@
   metadata:
     name: mariadb
     namespace: test
-    labels:
-      chart: mariadb
   spec:
     chartGitPath: mariadb
     values:

--- a/releases/mongodb_release.yaml
+++ b/releases/mongodb_release.yaml
@@ -4,8 +4,6 @@
   metadata:
     name: mongodb
     namespace: test
-    labels:
-      chart: mongodb
   spec:
     chartGitPath: mongodb
     releaseName: mongodb-database


### PR DESCRIPTION
 According to @stefanprodan in https://github.com/weaveworks/flux/pull/1357/files/1e132ef8a381098719b158c3c4c9e13e33377506#diff-53bc9f3e6f2346d63bebde98ebe00110 they are not needed any more.

Confirmed with our [helm get started tutorial](https://github.com/weaveworks/flux/blob/master/site/helm/get-started.md).